### PR TITLE
Fix debug builds on gcc 8

### DIFF
--- a/include/la/avdecc/internals/protocolVuAecpdu.hpp
+++ b/include/la/avdecc/internals/protocolVuAecpdu.hpp
@@ -88,7 +88,7 @@ public:
 		{
 			ArrayType value{};
 
-			for (auto i = 0; i < Size; ++i)
+			for (auto i = 0U; i < Size; ++i)
 			{
 				value[i] = static_cast<ArrayType::value_type>((_identifier >> ((Size - 1 - i) * 8)) & 0x00000000000000FF);
 			}

--- a/include/la/avdecc/utils.hpp
+++ b/include/la/avdecc/utils.hpp
@@ -362,7 +362,7 @@ public:
 	}
 
 	/** Clears the specified flag. If passed value is not valid (not exactly one bit set), this leads to undefined behavior. */
-	EnumBitfield& reset(value_type const flag) noexcept
+	constexpr EnumBitfield& reset(value_type const flag) noexcept
 	{
 		checkInvalidValue(flag);
 		_value &= ~to_integral(flag);

--- a/include/la/avdecc/utils.hpp
+++ b/include/la/avdecc/utils.hpp
@@ -283,13 +283,9 @@ public:
 			}
 			return *this;
 		}
-		reference operator*() noexcept
+		value_type operator*() noexcept
 		{
-			return *reinterpret_cast<pointer>(&_currentValue);
-		}
-		const_reference operator*() const noexcept
-		{
-			return *reinterpret_cast<const_pointer>(&_currentValue);
+			return static_cast<value_type>(_currentValue);
 		}
 		pointer operator->() noexcept
 		{

--- a/include/la/avdecc/utils.hpp
+++ b/include/la/avdecc/utils.hpp
@@ -235,8 +235,6 @@ public:
 		static constexpr auto EndBit = value_size;
 
 	public:
-		using value_type = value_type;
-		using underlying_value_type = underlying_value_type;
 		using difference_type = size_t;
 		using iterator_category = std::forward_iterator_tag;
 		using reference = value_type&;

--- a/include/la/avdecc/watchDog.hpp
+++ b/include/la/avdecc/watchDog.hpp
@@ -27,6 +27,7 @@
 
 #include "utils.hpp"
 #include "internals/exports.hpp"
+#include <memory>
 #include <mutex>
 #include <string>
 #include <chrono>

--- a/src/streamFormat.cpp
+++ b/src/streamFormat.cpp
@@ -617,11 +617,9 @@ StreamFormat LA_AVDECC_CALL_CONVENTION StreamFormatInfo::buildFormat_IEC_61883_6
 	replaceField<8, 8>(fmt, static_cast<std::uint8_t>(1)); // sf = IEC 61883
 	replaceField<9, 14>(fmt, static_cast<std::uint8_t>(0x10)); // fmt = IEC 61883-6
 
-	std::uint8_t fdf_evt{ 0u };
 	switch (sampleFormat)
 	{
 		case SampleFormat::Int24: // IEC 61883-6 AM824
-			fdf_evt = 0x00;
 			break;
 		case SampleFormat::FixedPoint32: // IEC 61883-6 32-bit fixed point packetization
 			[[fallthrough]]; // Not supported
@@ -630,7 +628,7 @@ StreamFormat LA_AVDECC_CALL_CONVENTION StreamFormatInfo::buildFormat_IEC_61883_6
 		default:
 			return getNullStreamFormat();
 	}
-	replaceField<16, 20>(fmt, static_cast<std::uint8_t>(0x0)); // fdf_evt = sampleFormat
+	replaceField<16, 20>(fmt, static_cast<std::uint8_t>(0x0));
 
 	std::uint8_t fdf_sfc{ 0u };
 	switch (samplingRate)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -152,14 +152,14 @@ void LA_AVDECC_CALL_CONVENTION displayAssertDialog(char const* const file, unsig
 	{
 		char buffer[2048];
 		auto offset = std::snprintf(buffer, sizeof(buffer), "Debug Assertion Failed!\n\nFile: %s\nLine: %u\n\n\t", file, line);
-		if (offset < sizeof(buffer) - 1)
+		if (offset < static_cast<ssize_t>(sizeof(buffer) - 1))
 		{
 			offset += std::vsnprintf(buffer + offset, sizeof(buffer) - offset, message, arg);
 			buffer[sizeof(buffer) - 1] = 0; // Contrary to std::snprintf, std::vsnprintf does not add \0 if there is not enough room
 
 			std::cerr << buffer << std::endl;
 
-			if (offset < sizeof(buffer) - 1)
+			if (offset < static_cast<ssize_t>(sizeof(buffer) - 1))
 			{
 				offset += std::snprintf(buffer + offset, sizeof(buffer) - offset,
 					"\n"


### PR DESCRIPTION
This fixes various warnings that made debug builds using gcc 8 impossible.