### PR TITLE
get tlv.size() before move

### DIFF
--- a/src/controller/avdeccControllerImplOverrides.cpp
+++ b/src/controller/avdeccControllerImplOverrides.cpp
@@ -2058,8 +2058,9 @@ void ControllerImpl::writeDeviceMemory(UniqueIdentifier const targetEntityID, st
 		{
 			LOG_CONTROLLER_TRACE(targetEntityID, "User writeDeviceMemory chunk (BaseAddress={}, Length={}, Pos={}, ChunkLength={})", utils::toHexString(address, true), memoryBuffer.size(), 0, tlv.size());
 			auto const guard = ControlledEntityUnlockerGuard{ *this }; // Always temporarily unlock the ControlledEntities before calling the controller
+			auto const tlvSize = tlv.size();
 			_controller->addressAccess(targetEntityID, { std::move(tlv) },
-				[this, baseAddress = address, sentSize = tlv.size(), progressHandlerCopy = progressHandler, completionHandlerCopy = completionHandler, memoryBuffer = std::move(memoryBuffer)](entity::controller::Interface const* const /*controller*/, UniqueIdentifier const entityID, entity::ControllerEntity::AaCommandStatus const status, entity::addressAccess::Tlvs const& /*tlvs*/) mutable
+				[this, baseAddress = address, sentSize = tlvSize, progressHandlerCopy = progressHandler, completionHandlerCopy = completionHandler, memoryBuffer = std::move(memoryBuffer)](entity::controller::Interface const* const /*controller*/, UniqueIdentifier const entityID, entity::ControllerEntity::AaCommandStatus const status, entity::addressAccess::Tlvs const& /*tlvs*/) mutable
 				{
 					onUserWriteDeviceMemoryResult(entityID, status, baseAddress, sentSize, std::move(progressHandlerCopy), std::move(completionHandlerCopy), std::move(memoryBuffer));
 				});


### PR DESCRIPTION
fixes writeDeviceMemory(), otherwise sendSize is always 0 and address does not increment