### PR TITLE
Fix examples and update clang-format 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortLambdasOnASingleLine: Empty
+AllowAllArgumentsOnNextLine: true
 
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false

--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+AllowShortLambdasOnASingleLine: Empty
 
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
@@ -50,6 +51,7 @@ BraceWrapping:
     SplitEmptyRecord: true
     SplitEmptyNamespace: true
     BeforeLambdaBody: true
+    AfterCaseLabel: true
 
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: false

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /externals/3rdparty/winpcap/Include
 /externals/3rdparty/winpcap/Lib
 
+CMakeFiles

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ echo "/usr/local/bin/bash" | sudo tee -a /etc/shells
 chsh -s /usr/local/bin/bash
 ```
 
-* Install latest `clang-format`
+* Install latest `clang-format` (11.x)
 
 ```bash
 brew install romansavrulin/clang-format/clang-format-lambda --HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,19 @@ Read and follow the coding style and guidelines [from this file](CODING_STYLE_GU
 - Don't forget to update any impacted CHANGELOG file(s)
 - Run the *fix_files.sh* script
 - Start a github pull request
+
+## To run `fix_files.sh` on MAC
+
+* Update `bash` from 3.x to latest (5.x)
+
+```bash
+brew install bash
+echo "/usr/local/bin/bash" | sudo tee -a /etc/shells
+chsh -s /usr/local/bin/bash
+```
+
+* Install latest `clang-format`
+
+```bash
+brew install romansavrulin/clang-format/clang-format-lambda --HEAD
+```

--- a/examples/src/discovery.cpp
+++ b/examples/src/discovery.cpp
@@ -147,7 +147,8 @@ void Discovery::onEntityOnline(la::avdecc::controller::Controller const* const /
 			auto const& obj = objIt.second;
 			if (obj.staticModel->memoryObjectType == la::avdecc::entity::model::MemoryObjectType::PngEntity)
 			{
-				_controller->readDeviceMemory(entity->getEntity().getEntityID(), obj.staticModel->startAddress, obj.staticModel->maximumLength,
+				_controller->readDeviceMemory(
+					entity->getEntity().getEntityID(), obj.staticModel->startAddress, obj.staticModel->maximumLength,
 					[](la::avdecc::controller::ControlledEntity const* const /*entity*/, float const percentComplete)
 					{
 						outputText("Memory Object progress: " + std::to_string(percentComplete) + "\n");

--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -34,6 +34,18 @@ static SCREEN* s_Screen = nullptr;
 #	include <iostream>
 #endif // USE_CURSES
 
+int _getch()
+{
+	if (s_Window == nullptr)
+		return 0;
+#if defined(USE_CURSES)
+	int c = wgetch(s_Window);
+#else
+	int c = getch();
+#endif
+	c -= '0';
+	return c;
+}
 
 void initOutput()
 {
@@ -114,12 +126,7 @@ la::avdecc::protocol::ProtocolInterface::Type chooseProtocolInterfaceType(la::av
 		int index = -1;
 		while (index == -1)
 		{
-#if defined(USE_CURSES)
-			int c = wgetch(s_Window);
-#else
-			int c = getch();
-#endif
-			c -= '0';
+			auto c = _getch();
 			if (c >= 1 && c <= static_cast<int>(protocolInterfaceTypes.count()))
 			{
 				index = c - 1;
@@ -165,12 +172,7 @@ la::avdecc::networkInterface::Interface chooseNetworkInterface()
 	int index = -1;
 	while (index == -1)
 	{
-#if defined(USE_CURSES)
-		int c = wgetch(s_Window);
-#else
-		int c = getch();
-#endif
-		c -= '0';
+		auto c = _getch();
 		if (c >= 1 && c <= static_cast<int>(interfaces.size()))
 		{
 			index = c - 1;

--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -115,11 +115,11 @@ la::avdecc::protocol::ProtocolInterface::Type chooseProtocolInterfaceType(la::av
 		while (index == -1)
 		{
 #if defined(USE_CURSES)
-            int c = wgetch(s_Window);
+			int c = wgetch(s_Window);
 #else
-            int c = getch();
+			int c = getch();
 #endif
-            c -= '0';
+			c -= '0';
 			if (c >= 1 && c <= static_cast<int>(protocolInterfaceTypes.count()))
 			{
 				index = c - 1;
@@ -168,9 +168,9 @@ la::avdecc::networkInterface::Interface chooseNetworkInterface()
 #if defined(USE_CURSES)
 		int c = wgetch(s_Window);
 #else
-        int c = getch();
+		int c = getch();
 #endif
-        c -= '0';
+		c -= '0';
 		if (c >= 1 && c <= static_cast<int>(interfaces.size()))
 		{
 			index = c - 1;

--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -114,7 +114,12 @@ la::avdecc::protocol::ProtocolInterface::Type chooseProtocolInterfaceType(la::av
 		int index = -1;
 		while (index == -1)
 		{
-			int c = getch() - '0';
+#if defined(USE_CURSES)
+            int c = wgetch(s_Window);
+#else
+            int c = getch();
+#endif
+            c -= '0';
 			if (c >= 1 && c <= static_cast<int>(protocolInterfaceTypes.count()))
 			{
 				index = c - 1;
@@ -160,7 +165,12 @@ la::avdecc::networkInterface::Interface chooseNetworkInterface()
 	int index = -1;
 	while (index == -1)
 	{
-		int c = getch() - '0';
+#if defined(USE_CURSES)
+		int c = wgetch(s_Window);
+#else
+        int c = getch();
+#endif
+        c -= '0';
 		if (c >= 1 && c <= static_cast<int>(interfaces.size()))
 		{
 			index = c - 1;

--- a/scripts/fix_files.sh
+++ b/scripts/fix_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FIX_FILES_VERSION="1.5"
 
@@ -6,7 +6,7 @@ echo "Fix-Files version $FIX_FILES_VERSION"
 echo ""
 
 # Check bash version
-if [[ ${BASH_VERSINFO[0]} < 5 && (${BASH_VERSINFO[0]} < 4 || ${BASH_VERSINFO[1]} < 1) ]]; then
+  if [[ ${BASH_VERSINFO[0]} < 5 && (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} < 1) ]]; then
   echo "bash 4.1 or later required"
   exit 255
 fi
@@ -81,8 +81,9 @@ if [[ $do_clang_format -eq 1 && -f ./.clang-format ]]; then
 	if [ $? -eq 0 ]; then
 		cf_version="$(clang-format --version)"
 		regex="clang-format version 7\.0\.0 \(tags\/RELEASE_700\/final[ 0-9]*\/WithWrappingBeforeLambdaBodyPatch\)"
-		if [[ ! "$cf_version" =~ $regex ]]; then
-			echo "Incorrect clang-format: Version 7.0.0 with WrappingBeforeLambdaBody patch required (found: $cf_version)"
+		regex2="clang-format version 1[1-9]\.[ 0-9]*"
+		if [[ ! ( "$cf_version" =~ $regex) && ! ("$cf_version" =~ $regex2) ]]; then
+			echo "Incorrect clang-format: Version 7.0.0 with WrappingBeforeLambdaBody patch or Version > 10.0 required (found: $cf_version)"
 			exit 1
 		fi
 		applyFormat "*.[chi]pp"

--- a/scripts/fix_files.sh
+++ b/scripts/fix_files.sh
@@ -6,7 +6,7 @@ echo "Fix-Files version $FIX_FILES_VERSION"
 echo ""
 
 # Check bash version
-  if [[ ${BASH_VERSINFO[0]} < 5 && (${BASH_VERSINFO[0]} == 4 && ${BASH_VERSINFO[1]} < 1) ]]; then
+  if [[ ${BASH_VERSINFO[0]} < 5 && (${BASH_VERSINFO[0]} < 4 || ${BASH_VERSINFO[1]} < 1) ]]; then
   echo "bash 4.1 or later required"
   exit 255
 fi
@@ -81,7 +81,7 @@ if [[ $do_clang_format -eq 1 && -f ./.clang-format ]]; then
 	if [ $? -eq 0 ]; then
 		cf_version="$(clang-format --version)"
 		regex="clang-format version 7\.0\.0 \(tags\/RELEASE_700\/final[ 0-9]*\/WithWrappingBeforeLambdaBodyPatch\)"
-		regex2="clang-format version 1[1-9]\.[ 0-9]*"
+		regex2="clang-format version 11\.[ 0-9]*"
 		if [[ ! ( "$cf_version" =~ $regex) && ! ("$cf_version" =~ $regex2) ]]; then
 			echo "Incorrect clang-format: Version 7.0.0 with WrappingBeforeLambdaBody patch or Version > 10.0 required (found: $cf_version)"
 			exit 1

--- a/src/entity/entityImpl.hpp
+++ b/src/entity/entityImpl.hpp
@@ -193,9 +193,7 @@ public:
 		if (handler)
 			return std::bind(handler, object, std::forward<Ts>(params)...);
 		// No handler specified, return an empty handler
-		return [](LocalEntity::AemCommandStatus const /*error*/)
-		{
-		};
+		return [](LocalEntity::AemCommandStatus const /*error*/) {};
 	}
 	template<typename T, typename Object, typename... Ts>
 	static OnAaAECPErrorCallback makeAaAECPErrorHandler(T const& handler, Object const* const object, Ts&&... params)
@@ -203,9 +201,7 @@ public:
 		if (handler)
 			return std::bind(handler, object, std::forward<Ts>(params)...);
 		// No handler specified, return an empty handler
-		return [](LocalEntity::AaCommandStatus const /*error*/)
-		{
-		};
+		return [](LocalEntity::AaCommandStatus const /*error*/) {};
 	}
 	template<typename T, typename Object, typename... Ts>
 	static OnMvuAECPErrorCallback makeMvuAECPErrorHandler(T const& handler, Object const* const object, Ts&&... params)
@@ -213,9 +209,7 @@ public:
 		if (handler)
 			return std::bind(handler, object, std::forward<Ts>(params)...);
 		// No handler specified, return an empty handler
-		return [](LocalEntity::MvuCommandStatus const /*error*/)
-		{
-		};
+		return [](LocalEntity::MvuCommandStatus const /*error*/) {};
 	}
 	template<typename T, typename Object, typename... Ts>
 	static OnACMPErrorCallback makeACMPErrorHandler(T const& handler, Object const* const object, Ts&&... params)
@@ -223,9 +217,7 @@ public:
 		if (handler)
 			return std::bind(handler, object, std::forward<Ts>(params)...);
 		// No handler specified, return an empty handler
-		return [](LocalEntity::ControlStatus const /*error*/)
-		{
-		};
+		return [](LocalEntity::ControlStatus const /*error*/) {};
 	}
 
 	static LocalEntity::AemCommandStatus convertErrorToAemCommandStatus(protocol::ProtocolInterface::Error const error) noexcept;

--- a/src/networkInterfaceHelper/networkInterfaceHelper_win32.cpp
+++ b/src/networkInterfaceHelper/networkInterfaceHelper_win32.cpp
@@ -51,7 +51,7 @@
 
 #if defined(_WIN32) && defined(__clang__)
 // Right now, we need to silence "ISO C++11 does not allow conversion from string literal to 'BSTR'" warning for MSVC ClangCL
-#pragma clang diagnostic ignored "-Wwritable-strings"
+#	pragma clang diagnostic ignored "-Wwritable-strings"
 #endif
 
 namespace la

--- a/src/protocolInterface/protocolInterface_macNative.mm
+++ b/src/protocolInterface/protocolInterface_macNative.mm
@@ -67,7 +67,8 @@ class ProtocolInterfaceMacNativeImpl;
 #pragma mark - FromNative Implementation
 
 @implementation FromNative
-+ (la::avdecc::networkInterface::MacAddress)getFirstMacAddress:(NSArray*)array {
++ (la::avdecc::networkInterface::MacAddress)getFirstMacAddress:(NSArray*)array
+{
 	la::avdecc::networkInterface::MacAddress mac;
 
 	if (array.count > 0)
@@ -86,7 +87,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return mac;
 }
 
-+ (la::avdecc::entity::Entity)makeEntity:(AVB17221Entity*)entity {
++ (la::avdecc::entity::Entity)makeEntity:(AVB17221Entity*)entity
+{
 	auto entityCaps = la::avdecc::entity::EntityCapabilities{};
 	entityCaps.assign(static_cast<la::avdecc::entity::EntityCapabilities::underlying_value_type>(entity.entityCapabilities));
 	auto talkerCaps = la::avdecc::entity::TalkerCapabilities{};
@@ -125,7 +127,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return la::avdecc::entity::Entity{ commonInfo, { { avbInterfaceIndex, interfaceInfo } } };
 }
 
-+ (la::avdecc::protocol::AemAecpdu::UniquePointer)makeAemAecpdu:(AVB17221AECPAEMMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse {
++ (la::avdecc::protocol::AemAecpdu::UniquePointer)makeAemAecpdu:(AVB17221AECPAEMMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse
+{
 	auto aemAecpdu = la::avdecc::protocol::AemAecpdu::create(isResponse);
 	auto& aem = static_cast<la::avdecc::protocol::AemAecpdu&>(*aemAecpdu);
 
@@ -148,7 +151,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return aemAecpdu;
 }
 
-+ (la::avdecc::protocol::AaAecpdu::UniquePointer)makeAaAecpdu:(AVB17221AECPAddressAccessMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse {
++ (la::avdecc::protocol::AaAecpdu::UniquePointer)makeAaAecpdu:(AVB17221AECPAddressAccessMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse
+{
 	auto aaAecpdu = la::avdecc::protocol::AaAecpdu::create(isResponse);
 	auto& aa = static_cast<la::avdecc::protocol::AaAecpdu&>(*aaAecpdu);
 
@@ -171,12 +175,14 @@ class ProtocolInterfaceMacNativeImpl;
 	return aaAecpdu;
 }
 
-+ (la::avdecc::protocol::VuAecpdu::UniquePointer)makeVendorUniqueAecpdu:(AVB17221AECPVendorMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse {
++ (la::avdecc::protocol::VuAecpdu::UniquePointer)makeVendorUniqueAecpdu:(AVB17221AECPVendorMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress isResponse:(bool)isResponse
+{
 #pragma message("TODO")
 	return la::avdecc::protocol::VuAecpdu::UniquePointer{ nullptr, nullptr };
 }
 
-+ (la::avdecc::protocol::Aecpdu::UniquePointer)makeAecpdu:(AVB17221AECPMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress {
++ (la::avdecc::protocol::Aecpdu::UniquePointer)makeAecpdu:(AVB17221AECPMessage*)message toDestAddress:(la::avdecc::networkInterface::MacAddress const&)destAddress
+{
 	switch ([message messageType])
 	{
 		case AVB17221AECPMessageTypeAEMCommand:
@@ -198,7 +204,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return { nullptr, nullptr };
 }
 
-+ (la::avdecc::protocol::Acmpdu::UniquePointer)makeAcmpdu:(AVB17221ACMPMessage*)message {
++ (la::avdecc::protocol::Acmpdu::UniquePointer)makeAcmpdu:(AVB17221ACMPMessage*)message
+{
 	auto acmpdu = la::avdecc::protocol::Acmpdu::create();
 	auto& acmp = static_cast<la::avdecc::protocol::Acmpdu&>(*acmpdu);
 
@@ -227,7 +234,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return acmpdu;
 }
 
-+ (la::avdecc::networkInterface::MacAddress)makeMacAddress:(AVBMACAddress*)macAddress {
++ (la::avdecc::networkInterface::MacAddress)makeMacAddress:(AVBMACAddress*)macAddress
+{
 	la::avdecc::networkInterface::MacAddress mac;
 	auto const* data = [macAddress dataRepresentation];
 	auto const bufferSize = mac.size() * sizeof(la::avdecc::networkInterface::MacAddress::value_type);
@@ -238,7 +246,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return mac;
 }
 
-+ (la::avdecc::protocol::ProtocolInterface::Error)getProtocolError:(NSError*)error {
++ (la::avdecc::protocol::ProtocolInterface::Error)getProtocolError:(NSError*)error
+{
 	if ([[error domain] isEqualToString:AVBErrorDomain])
 	{
 		auto const code = IOReturn(error.code);
@@ -277,7 +286,8 @@ class ProtocolInterfaceMacNativeImpl;
 #pragma mark - ToNative Implementation
 
 @implementation ToNative
-+ (AVB17221Entity*)makeAVB17221Entity:(la::avdecc::entity::Entity const&)entity interfaceIndex:(la::avdecc::entity::model::AvbInterfaceIndex)interfaceIndex {
++ (AVB17221Entity*)makeAVB17221Entity:(la::avdecc::entity::Entity const&)entity interfaceIndex:(la::avdecc::entity::model::AvbInterfaceIndex)interfaceIndex
+{
 	auto& interfaceInfo = entity.getInterfaceInformation(interfaceIndex);
 	auto entityCaps{ entity.getEntityCapabilities() };
 	auto identifyControlIndex{ la::avdecc::entity::model::ControlIndex{ 0u } };
@@ -355,7 +365,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return e;
 }
 
-+ (AVB17221AECPAEMMessage*)makeAemMessage:(la::avdecc::protocol::AemAecpdu const&)aecpdu isResponse:(bool)isResponse {
++ (AVB17221AECPAEMMessage*)makeAemMessage:(la::avdecc::protocol::AemAecpdu const&)aecpdu isResponse:(bool)isResponse
+{
 	auto* message = static_cast<AVB17221AECPAEMMessage*>(nullptr);
 
 	if (isResponse)
@@ -383,7 +394,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return message;
 }
 
-+ (AVB17221AECPAddressAccessMessage*)makeAaMessage:(la::avdecc::protocol::AaAecpdu const&)aecpdu isResponse:(bool)isResponse {
++ (AVB17221AECPAddressAccessMessage*)makeAaMessage:(la::avdecc::protocol::AaAecpdu const&)aecpdu isResponse:(bool)isResponse
+{
 	auto* message = static_cast<AVB17221AECPAddressAccessMessage*>(nullptr);
 
 	if (isResponse)
@@ -412,7 +424,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return message;
 }
 
-+ (AVB17221AECPVendorMessage*)makeVendorUniqueMessage:(la::avdecc::protocol::VuAecpdu const&)aecpdu isResponse:(bool)isResponse {
++ (AVB17221AECPVendorMessage*)makeVendorUniqueMessage:(la::avdecc::protocol::VuAecpdu const&)aecpdu isResponse:(bool)isResponse
+{
 	auto const message = [[AVB17221AECPVendorMessage alloc] init];
 #if !__has_feature(objc_arc)
 	[message autorelease];
@@ -447,7 +460,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return message;
 }
 
-+ (AVB17221AECPMessage*)makeAecpMessage:(la::avdecc::protocol::Aecpdu const&)message {
++ (AVB17221AECPMessage*)makeAecpMessage:(la::avdecc::protocol::Aecpdu const&)message
+{
 	switch (static_cast<AVB17221AECPMessageType>(message.getMessageType().getValue()))
 	{
 		case AVB17221AECPMessageTypeAEMCommand:
@@ -469,7 +483,8 @@ class ProtocolInterfaceMacNativeImpl;
 	return NULL;
 }
 
-+ (AVBMACAddress*)makeAVBMacAddress:(la::avdecc::networkInterface::MacAddress const&)macAddress {
++ (AVBMACAddress*)makeAVBMacAddress:(la::avdecc::networkInterface::MacAddress const&)macAddress
+{
 	auto* mac = [[AVBMACAddress alloc] initWithBytes:macAddress.data()];
 #if !__has_feature(objc_arc)
 	[mac autorelease];
@@ -824,14 +839,16 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 #pragma mark - BridgeInterface Implementation
 @implementation BridgeInterface
 
-- (EntityQueues const&)createQueuesForRemoteEntity:(la::avdecc::UniqueIdentifier)entityID {
+- (EntityQueues const&)createQueuesForRemoteEntity:(la::avdecc::UniqueIdentifier)entityID
+{
 	EntityQueues eq;
 	eq.aecpQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.0x%016llx.aecp", [self className], entityID.getValue()] UTF8String], 0);
 	eq.aecpLimiter = dispatch_semaphore_create(la::avdecc::protocol::Aecpdu::DefaultMaxInflightCommands);
 	return _entityQueues[entityID] = std::move(eq);
 }
 
-+ (BOOL)isSupported {
++ (BOOL)isSupported
+{
 	if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)])
 	{
 		// Minimum required version is macOS 10.11.0 (El Capitan)
@@ -842,25 +859,30 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 /** std::string to NSString conversion */
-+ (NSString*)getNSString:(std::string const&)cString {
++ (NSString*)getNSString:(std::string const&)cString
+{
 	return [NSString stringWithCString:cString.c_str() encoding:NSUTF8StringEncoding];
 }
 
 /** NSString to std::string conversion */
-+ (std::string)getStdString:(NSString*)nsString {
++ (std::string)getStdString:(NSString*)nsString
+{
 	return std::string{ [nsString UTF8String] };
 }
 
-+ (NSString*)getEntityCapabilities:(AVB17221Entity*)entity {
++ (NSString*)getEntityCapabilities:(AVB17221Entity*)entity
+{
 	return [NSString stringWithFormat:@"%@ %@ %@", (entity.talkerCapabilities & AVB17221ADPTalkerCapabilitiesImplemented) ? @"Talker" : @"", (entity.listenerCapabilities & AVB17221ADPListenerCapabilitiesImplemented) ? @"Listener" : @"", (entity.controllerCapabilities & AVB17221ADPControllerCapabilitiesImplemented) ? @"Controller" : @""];
 }
 
-- (void)startAsyncOperation {
+- (void)startAsyncOperation
+{
 	std::lock_guard<decltype(_lockPending)> const lg(_lockPending);
 	_pendingCommands++;
 }
 
-- (void)stopAsyncOperation {
+- (void)stopAsyncOperation
+{
 	{
 		std::lock_guard<decltype(_lockPending)> const lg(_lockPending);
 		AVDECC_ASSERT(_pendingCommands > 0, "Trying to stop async operation, but there is no pending operation");
@@ -869,7 +891,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	_pendingCondVar.notify_all();
 }
 
-- (void)waitAsyncOperations {
+- (void)waitAsyncOperations
+{
 	// Wait for all remaining async operations to complete
 	std::unique_lock<decltype(_lockPending)> sync_lg(_lockPending);
 	_pendingCondVar.wait(sync_lg,
@@ -880,7 +903,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	AVDECC_ASSERT(_pendingCommands == 0, "Waited for pending operations to complete, but there is some remaining one!");
 }
 
-- (std::optional<la::avdecc::entity::model::AvbInterfaceIndex>)getMatchingInterfaceIndex:(la::avdecc::entity::LocalEntity const&)entity {
+- (std::optional<la::avdecc::entity::model::AvbInterfaceIndex>)getMatchingInterfaceIndex:(la::avdecc::entity::LocalEntity const&)entity
+{
 	auto avbInterfaceIndex = std::optional<la::avdecc::entity::model::AvbInterfaceIndex>{ std::nullopt };
 	auto const& macAddress = _protocolInterface->getMacAddress();
 
@@ -897,7 +921,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 /** Initializer */
-- (id)initWithInterfaceName:(NSString*)interfaceName andProtocolInterface:(la::avdecc::protocol::ProtocolInterfaceMacNativeImpl*)protocolInterface {
+- (id)initWithInterfaceName:(NSString*)interfaceName andProtocolInterface:(la::avdecc::protocol::ProtocolInterfaceMacNativeImpl*)protocolInterface
+{
 	self = [super init];
 	if (self)
 	{
@@ -911,7 +936,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 /** Deinit method to shutdown every pending operations */
-- (void)deinit {
+- (void)deinit
+{
 	// Remove discovery delegate
 	self.interface.entityDiscovery.discoveryDelegate = nil;
 
@@ -949,7 +975,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 /** Destructor */
-- (void)dealloc {
+- (void)dealloc
+{
 	[self deinit];
 #if !__has_feature(objc_arc)
 	[super dealloc];
@@ -957,16 +984,19 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 #pragma mark la::avdecc::protocol::ProtocolInterface bridge methods
-- (la::avdecc::UniqueIdentifier)getDynamicEID {
+- (la::avdecc::UniqueIdentifier)getDynamicEID
+{
 	return la::avdecc::UniqueIdentifier{ [AVBCentralManager nextAvailableDynamicEntityID] };
 }
 
-- (void)releaseDynamicEID:(la::avdecc::UniqueIdentifier)entityID {
+- (void)releaseDynamicEID:(la::avdecc::UniqueIdentifier)entityID
+{
 	[AVBCentralManager releaseDynamicEntityID:entityID];
 }
 
 // Registration of a local process entity (an entity declared inside this process, not all local computer entities)
-- (la::avdecc::protocol::ProtocolInterface::Error)registerLocalEntity:(la::avdecc::entity::LocalEntity&)entity {
+- (la::avdecc::protocol::ProtocolInterface::Error)registerLocalEntity:(la::avdecc::entity::LocalEntity&)entity
+{
 	// Lock entities now, so we don't get interrupted during registration
 	auto const lg = std::lock_guard{ _lock };
 
@@ -1002,7 +1032,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 // Remove handlers for a local process entity
-- (void)removeLocalProcessEntityHandlers:(la::avdecc::entity::LocalEntity const&)entity {
+- (void)removeLocalProcessEntityHandlers:(la::avdecc::entity::LocalEntity const&)entity
+{
 	auto const entityID = entity.getEntityID();
 
 	// Entity is controller capable
@@ -1015,7 +1046,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 // Unregistration of a local process entity
-- (la::avdecc::protocol::ProtocolInterface::Error)unregisterLocalEntity:(la::avdecc::entity::LocalEntity const&)entity {
+- (la::avdecc::protocol::ProtocolInterface::Error)unregisterLocalEntity:(la::avdecc::entity::LocalEntity const&)entity
+{
 	auto const entityID = entity.getEntityID();
 
 	// Remove handlers
@@ -1036,7 +1068,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)setEntityNeedsAdvertise:(const la::avdecc::entity::LocalEntity&)entity flags:(la::avdecc::entity::LocalEntity::AdvertiseFlags)flags {
+- (la::avdecc::protocol::ProtocolInterface::Error)setEntityNeedsAdvertise:(const la::avdecc::entity::LocalEntity&)entity flags:(la::avdecc::entity::LocalEntity::AdvertiseFlags)flags
+{
 	NSError* error{ nullptr };
 
 	// Change in GrandMaster
@@ -1059,7 +1092,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)enableEntityAdvertising:(la::avdecc::entity::LocalEntity const&)entity {
+- (la::avdecc::protocol::ProtocolInterface::Error)enableEntityAdvertising:(la::avdecc::entity::LocalEntity const&)entity
+{
 	NSError* error{ nullptr };
 
 	auto const interfaceIndex = [self getMatchingInterfaceIndex:entity];
@@ -1075,7 +1109,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)disableEntityAdvertising:(la::avdecc::entity::LocalEntity const&)entity {
+- (la::avdecc::protocol::ProtocolInterface::Error)disableEntityAdvertising:(la::avdecc::entity::LocalEntity const&)entity
+{
 	NSError* error{ nullptr };
 
 	[self.interface.entityDiscovery removeLocalEntity:entity.getEntityID() error:&error];
@@ -1085,7 +1120,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (BOOL)discoverRemoteEntities {
+- (BOOL)discoverRemoteEntities
+{
 	if (!_primedDiscovery)
 	{
 		[self.interface.entityDiscovery primeIterators];
@@ -1095,7 +1131,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return [self.interface.entityDiscovery discoverEntities];
 }
 
-- (BOOL)discoverRemoteEntity:(la::avdecc::UniqueIdentifier)entityID {
+- (BOOL)discoverRemoteEntity:(la::avdecc::UniqueIdentifier)entityID
+{
 	if (!_primedDiscovery)
 	{
 		[self.interface.entityDiscovery primeIterators];
@@ -1105,7 +1142,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return [self.interface.entityDiscovery discoverEntity:entityID];
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)sendAecpCommand:(la::avdecc::protocol::Aecpdu::UniquePointer&&)aecpdu handler:(la::avdecc::protocol::ProtocolInterface::AecpCommandResultHandler const&)onResult {
+- (la::avdecc::protocol::ProtocolInterface::Error)sendAecpCommand:(la::avdecc::protocol::Aecpdu::UniquePointer&&)aecpdu handler:(la::avdecc::protocol::ProtocolInterface::AecpCommandResultHandler const&)onResult
+{
 	auto const macAddr = aecpdu->getDestAddress(); // Make a copy of the target macAddress so it can safely be used inside the objC block
 	__block auto resultHandler = onResult; // Make a copy of the handler so it can safely be used inside the objC block. Declare it as __block so we can modify it from the block (to fix a bug that macOS sometimes call the completionHandler twice)
 
@@ -1192,7 +1230,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)sendAecpResponse:(la::avdecc::protocol::Aecpdu::UniquePointer&&)aecpdu {
+- (la::avdecc::protocol::ProtocolInterface::Error)sendAecpResponse:(la::avdecc::protocol::Aecpdu::UniquePointer&&)aecpdu
+{
 	auto const macAddr = aecpdu->getDestAddress(); // Make a copy of the target macAddress so it can safely be used inside the objC block
 
 	auto message = [ToNative makeAecpMessage:*aecpdu];
@@ -1246,7 +1285,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (la::avdecc::protocol::ProtocolInterface::Error)sendAcmpCommand:(la::avdecc::protocol::Acmpdu::UniquePointer&&)acmpdu handler:(la::avdecc::protocol::ProtocolInterface::AcmpCommandResultHandler const&)onResult {
+- (la::avdecc::protocol::ProtocolInterface::Error)sendAcmpCommand:(la::avdecc::protocol::Acmpdu::UniquePointer&&)acmpdu handler:(la::avdecc::protocol::ProtocolInterface::AcmpCommandResultHandler const&)onResult
+{
 	__block auto resultHandler = onResult; // Make a copy of the handler so it can safely be used inside the objC block. Declare it as __block so we can modify it from the block (to fix a bug that macOS sometimes call the completionHandler twice)
 
 	auto const& acmp = static_cast<la::avdecc::protocol::Acmpdu const&>(*acmpdu);
@@ -1296,20 +1336,24 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return la::avdecc::protocol::ProtocolInterface::Error::NoError;
 }
 
-- (void)lock {
+- (void)lock
+{
 	_lock.lock();
 }
 
-- (void)unlock {
+- (void)unlock
+{
 	_lock.unlock();
 }
 
-- (bool)isSelfLocked {
+- (bool)isSelfLocked
+{
 	return _lock.isSelfLocked();
 }
 
 #pragma mark AVB17221EntityDiscoveryDelegate delegate
-- (void)initEntity:(la::avdecc::UniqueIdentifier)entityID {
+- (void)initEntity:(la::avdecc::UniqueIdentifier)entityID
+{
 	// Register ACMP sniffing handler for this entity
 	if ([self.interface.acmp setHandler:self forEntityID:entityID])
 	{
@@ -1325,7 +1369,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	}
 }
 
-- (void)deinitEntity:(la::avdecc::UniqueIdentifier)entityID {
+- (void)deinitEntity:(la::avdecc::UniqueIdentifier)entityID
+{
 	{
 		// Lock
 		auto const lg = std::lock_guard{ _lock };
@@ -1372,7 +1417,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 // Notification of an arriving local computer entity
-- (void)didAddLocalEntity:(AVB17221Entity*)newEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didAddLocalEntity:(AVB17221Entity*)newEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	[self initEntity:la::avdecc::UniqueIdentifier{ newEntity.entityID }];
 
 	// Lock
@@ -1384,7 +1430,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 // Notification of a departing local computer entity
-- (void)didRemoveLocalEntity:(AVB17221Entity*)oldEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didRemoveLocalEntity:(AVB17221Entity*)oldEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	auto const oldEntityID = la::avdecc::UniqueIdentifier{ oldEntity.entityID };
 	[self deinitEntity:oldEntityID];
 
@@ -1395,7 +1442,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	_protocolInterface->notifyObserversMethod<la::avdecc::protocol::ProtocolInterface::Observer>(&la::avdecc::protocol::ProtocolInterface::Observer::onLocalEntityOffline, _protocolInterface, oldEntityID);
 }
 
-- (void)didRediscoverLocalEntity:(AVB17221Entity*)entity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didRediscoverLocalEntity:(AVB17221Entity*)entity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	// Check if Entity already in the list
 	{
 		// Lock
@@ -1409,7 +1457,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	// Nothing to do, entity has already been detected
 }
 
-- (void)didUpdateLocalEntity:(AVB17221Entity*)entity changedProperties:(AVB17221EntityPropertyChanged)changedProperties on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didUpdateLocalEntity:(AVB17221Entity*)entity changedProperties:(AVB17221EntityPropertyChanged)changedProperties on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	constexpr NSUInteger ignoreChangeMask = 0xFFFFFFFF & ~(AVB17221EntityPropertyChangedTimeToLive | AVB17221EntityPropertyChangedAvailableIndex);
 	// If changes are only for flags we want to ignore, return
 	if ((changedProperties & ignoreChangeMask) == 0)
@@ -1432,7 +1481,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	}
 }
 
-- (void)didAddRemoteEntity:(AVB17221Entity*)newEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didAddRemoteEntity:(AVB17221Entity*)newEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	[self initEntity:la::avdecc::UniqueIdentifier{ newEntity.entityID }];
 
 	// Lock
@@ -1450,7 +1500,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	_protocolInterface->notifyObserversMethod<la::avdecc::protocol::ProtocolInterface::Observer>(&la::avdecc::protocol::ProtocolInterface::Observer::onRemoteEntityOnline, _protocolInterface, e);
 }
 
-- (void)didRemoveRemoteEntity:(AVB17221Entity*)oldEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didRemoveRemoteEntity:(AVB17221Entity*)oldEntity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	auto const oldEntityID = la::avdecc::UniqueIdentifier{ oldEntity.entityID };
 	[self deinitEntity:oldEntityID];
 
@@ -1464,7 +1515,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	_protocolInterface->notifyObserversMethod<la::avdecc::protocol::ProtocolInterface::Observer>(&la::avdecc::protocol::ProtocolInterface::Observer::onRemoteEntityOffline, _protocolInterface, oldEntityID);
 }
 
-- (void)didRediscoverRemoteEntity:(AVB17221Entity*)entity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didRediscoverRemoteEntity:(AVB17221Entity*)entity on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	// Check if Entity already in the list
 	{
 		// Lock
@@ -1478,7 +1530,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	// Nothing to do, entity has already been detected
 }
 
-- (void)didUpdateRemoteEntity:(AVB17221Entity*)entity changedProperties:(AVB17221EntityPropertyChanged)changedProperties on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery {
+- (void)didUpdateRemoteEntity:(AVB17221Entity*)entity changedProperties:(AVB17221EntityPropertyChanged)changedProperties on17221EntityDiscovery:(AVB17221EntityDiscovery*)entityDiscovery
+{
 	// Lock
 	auto const lg = std::lock_guard{ _lock };
 
@@ -1527,7 +1580,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 #pragma mark AVB17221AECPClient delegate
-- (BOOL)AECPDidReceiveCommand:(AVB17221AECPMessage*)message onInterface:(AVB17221AECPInterface*)anInterface {
+- (BOOL)AECPDidReceiveCommand:(AVB17221AECPMessage*)message onInterface:(AVB17221AECPInterface*)anInterface
+{
 	// This handler is called for all AECP commands targeting one of our registered Entities
 
 	// Lock
@@ -1545,7 +1599,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return YES;
 }
 
-- (BOOL)AECPDidReceiveResponse:(AVB17221AECPMessage*)message onInterface:(AVB17221AECPInterface*)anInterface {
+- (BOOL)AECPDidReceiveResponse:(AVB17221AECPMessage*)message onInterface:(AVB17221AECPInterface*)anInterface
+{
 	// This handler is called for all AECP responses targeting one of our registered Entities, even the messages that are solicited responses and which will be handled by the block of aecp.sendCommand() method
 
 	// Lock
@@ -1589,7 +1644,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 }
 
 #pragma mark AVB17221ACMPClient delegate
-- (BOOL)ACMPDidReceiveCommand:(AVB17221ACMPMessage*)message onInterface:(AVB17221ACMPInterface*)anInterface {
+- (BOOL)ACMPDidReceiveCommand:(AVB17221ACMPMessage*)message onInterface:(AVB17221ACMPInterface*)anInterface
+{
 	// This handler is called for all ACMP messages, even the messages that are sent by ourself
 
 	// Lock
@@ -1603,7 +1659,8 @@ ProtocolInterfaceMacNative* ProtocolInterfaceMacNative::createRawProtocolInterfa
 	return YES;
 }
 
-- (BOOL)ACMPDidReceiveResponse:(AVB17221ACMPMessage*)message onInterface:(AVB17221ACMPInterface*)anInterface {
+- (BOOL)ACMPDidReceiveResponse:(AVB17221ACMPMessage*)message onInterface:(AVB17221ACMPInterface*)anInterface
+{
 	// This handler is called for all ACMP messages, even the messages that are expected responses and which will be handled by the block of acmp.sendACMPCommandMessage() method
 
 	// Lock

--- a/src/stateMachine/discoveryStateMachine.hpp
+++ b/src/stateMachine/discoveryStateMachine.hpp
@@ -74,7 +74,7 @@ private:
 	};
 	struct DiscoveredEntityInfo
 	{
-		entity::Entity entity{ {},{} };
+		entity::Entity entity{ {}, {} };
 		std::unordered_map<entity::model::AvbInterfaceIndex, std::chrono::time_point<std::chrono::system_clock>> timeouts{};
 	};
 	using DiscoveredEntities = std::unordered_map<UniqueIdentifier, DiscoveredEntityInfo, UniqueIdentifier::hash>;


### PR DESCRIPTION
This PR 

- fixes blanking ncurses window on getch in examples
- adds extra steps to be taken on Mac to contribution guide
- allows to use mainline llvm codebase (11.x), where  `BeforeLambdaBody` option is available by default
- fixes `bash` and `clang-format` version checking
- formats some files with new `clang-format` tool