### PR TITLE
Fix blanking ncurses window on getch in examples

### DIFF
--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -34,11 +34,11 @@ static SCREEN* s_Screen = nullptr;
 #	include <iostream>
 #endif // USE_CURSES
 
-int _getch()
+int getUserChoice()
 {
-	if (s_Window == nullptr)
-		return 0;
 #if defined(USE_CURSES)
+    if (s_Window == nullptr)
+		return 0;
 	int c = wgetch(s_Window);
 #else
 	int c = getch();
@@ -126,7 +126,7 @@ la::avdecc::protocol::ProtocolInterface::Type chooseProtocolInterfaceType(la::av
 		int index = -1;
 		while (index == -1)
 		{
-			auto c = _getch();
+			auto c = getUserChoice();
 			if (c >= 1 && c <= static_cast<int>(protocolInterfaceTypes.count()))
 			{
 				index = c - 1;
@@ -172,7 +172,7 @@ la::avdecc::networkInterface::Interface chooseNetworkInterface()
 	int index = -1;
 	while (index == -1)
 	{
-		auto c = _getch();
+		auto c = getUserChoice();
 		if (c >= 1 && c <= static_cast<int>(interfaces.size()))
 		{
 			index = c - 1;

--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -34,6 +34,18 @@ static SCREEN* s_Screen = nullptr;
 #	include <iostream>
 #endif // USE_CURSES
 
+int _getch()
+{
+	if (s_Window == nullptr)
+		return 0;
+#if defined(USE_CURSES)
+	int c = wgetch(s_Window);
+#else
+	int c = getch();
+#endif
+	c -= '0';
+	return c;
+}
 
 void initOutput()
 {
@@ -114,7 +126,7 @@ la::avdecc::protocol::ProtocolInterface::Type chooseProtocolInterfaceType(la::av
 		int index = -1;
 		while (index == -1)
 		{
-			int c = getch() - '0';
+			auto c = _getch();
 			if (c >= 1 && c <= static_cast<int>(protocolInterfaceTypes.count()))
 			{
 				index = c - 1;
@@ -160,7 +172,7 @@ la::avdecc::networkInterface::Interface chooseNetworkInterface()
 	int index = -1;
 	while (index == -1)
 	{
-		int c = getch() - '0';
+		auto c = _getch();
 		if (c >= 1 && c <= static_cast<int>(interfaces.size()))
 		{
 			index = c - 1;

--- a/examples/src/utils.cpp
+++ b/examples/src/utils.cpp
@@ -37,7 +37,7 @@ static SCREEN* s_Screen = nullptr;
 int getUserChoice()
 {
 #if defined(USE_CURSES)
-    if (s_Window == nullptr)
+	if (s_Window == nullptr)
 		return 0;
 	int c = wgetch(s_Window);
 #else

--- a/scripts/fix_files.sh
+++ b/scripts/fix_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FIX_FILES_VERSION="1.5"
 


### PR DESCRIPTION
fix in a single PR, as you asked. Files are linted, so you can merge

refs:
https://stackoverflow.com/questions/19748685/curses-library-why-does-getch-clear-my-screen