### PR TITLE
Fix non-mac build with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ endif()
 
 ############ Compiler compatibility
 
-if(WIN32)
+if(MSVC)
 	if(${MSVC_VERSION} STRLESS 1923)
 		message(FATAL_ERROR "Microsoft Visual C++ v16.3 required (MSVC_VERSION >= 1923), you have ${MSVC_VERSION}")
 	endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,13 +41,13 @@ if(WIN32)
 	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
 		networkInterfaceHelper/networkInterfaceHelper_win32.cpp
 	)
-elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
-		networkInterfaceHelper/networkInterfaceHelper_unix.cpp
-	)
 elseif(CMAKE_HOST_APPLE)
 	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
 		networkInterfaceHelper/networkInterfaceHelper_mac.mm
+	)
+elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
+		networkInterfaceHelper/networkInterfaceHelper_unix.cpp
 	)
 endif()
 set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER ${SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER} networkInterfaceHelper/networkInterfaceHelper_common.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,18 +37,20 @@ if(WIN32)
 endif()
 
 # Network interface helper
-if(WIN32)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
 		networkInterfaceHelper/networkInterfaceHelper_win32.cpp
 	)
-elseif(CMAKE_HOST_APPLE)
-	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
-		networkInterfaceHelper/networkInterfaceHelper_mac.mm
-	)
-elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+elseif(CMAKE_SYSTEM_NAME MATCHES "(Linux)")
 	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
 		networkInterfaceHelper/networkInterfaceHelper_unix.cpp
 	)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER
+		networkInterfaceHelper/networkInterfaceHelper_mac.mm
+	)
+else()
+	message(FATAL_ERROR "Network helper undefined for system: ${CMAKE_SYSTEM_NAME}")
 endif()
 set (SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER ${SOURCE_FILES_CPP_NETWORK_INTERFACE_HELPER} networkInterfaceHelper/networkInterfaceHelper_common.cpp)
 set (HEADER_FILES_CPP_NETWORK_INTERFACE_HELPER networkInterfaceHelper/networkInterfaceHelper_common.hpp)


### PR DESCRIPTION
Unix implementation of networkInterfaceHelper is not compiled if
building with clang compiler on linux. This adds clang to lookup
list.