### PR TITLE
Clear correct step when fetching dynamic info

### DIFF
--- a/src/controller/avdeccControllerImpl.cpp
+++ b/src/controller/avdeccControllerImpl.cpp
@@ -2827,7 +2827,7 @@ void ControllerImpl::getDescriptorDynamicInfo(ControlledEntityImpl* const entity
 					// Get ConfigurationName
 					if (_usePackedDynamicInfo)
 					{
-						_dynamicInfoParameters.emplace_back(entity::controller::DynamicInfoParameter{ entity::LocalEntity::AemCommandStatus::Success, protocol::AemCommandType::GetName, { entity::model::DescriptorIndex{ 0u }, entity::model::DescriptorType::Configuration, configurationIndex, std::uint16_t{ 0u } } }); // CAUTION: configurationIndex should be set to 0 for CONFIGURATION_DESCRIPTOR, the index for the requested configuration name is actually passed as the descriptorIndex field
+						_dynamicInfoParameters.emplace_back(entity::controller::DynamicInfoParameter{ entity::LocalEntity::AemCommandStatus::Success, protocol::AemCommandType::GetName, { entity::model::ConfigurationIndex{ 0u }, entity::model::DescriptorType::Configuration, configurationIndex, std::uint16_t{ 0u } } }); // CAUTION: configurationIndex should be set to 0 for CONFIGURATION_DESCRIPTOR, the index for the requested configuration name is actually passed as the descriptorIndex field
 					}
 					else
 					{

--- a/src/controller/avdeccControllerImplHandlers.cpp
+++ b/src/controller/avdeccControllerImplHandlers.cpp
@@ -578,7 +578,7 @@ void ControllerImpl::onGetDynamicInfoResult(entity::controller::Interface const*
 				if ((step == ControlledEntityImpl::EnumerationStep::GetDescriptorDynamicInfo && entity.gotAllExpectedDescriptorDynamicInfo()) || (step == ControlledEntityImpl::EnumerationStep::GetDynamicInfo && entity.gotAllExpectedDynamicInfo()))
 				{
 					// Clear this enumeration step and check for next one
-					controlledEntity->clearEnumerationStep(ControlledEntityImpl::EnumerationStep::GetDescriptorDynamicInfo);
+					controlledEntity->clearEnumerationStep(step);
 					checkEnumerationSteps(&entity);
 				}
 			}


### PR DESCRIPTION
Without this change enumeration goes into a loop while fetching dynamic info.

I've also switched to the correct `uint16_t` alias for one GetName parameter.