### PR TITLE
Allow PCAP_LIBRARY to be overridden at compile time

### DIFF
--- a/src/protocolInterface/pcapDynamicLinking.cpp
+++ b/src/protocolInterface/pcapDynamicLinking.cpp
@@ -41,11 +41,13 @@
 #else
 #	include <dlfcn.h>
 #	include <signal.h>
-#	ifdef __APPLE__
-#		define PCAP_LIBRARY "/usr/lib/libpcap.dylib" /* Due to macOS hardened runtime, we have to specify the absolute path for the pcap library */
-#	else /* !__APPLE__ */
-#		define PCAP_LIBRARY "libpcap.so"
-#	endif /* __APPLE__ */
+#	ifndef PCAP_LIBRARY /* allow library name to be overridden to include soname */
+#		ifdef __APPLE__
+#			define PCAP_LIBRARY "/usr/lib/libpcap.dylib" /* Due to macOS hardened runtime, we have to specify the absolute path for the pcap library */
+#		else /* !__APPLE__ */
+#			define PCAP_LIBRARY "libpcap.so"
+#		endif /* __APPLE__ */
+#	endif /* !PCAP_LIBRARY */
 #	define DL_HANDLE void*
 #	define DL_OPEN(x) dlopen((x), RTLD_LAZY)
 #	define DL_CLOSE(x) dlclose(x)


### PR DESCRIPTION
This is useful for specifying the soname of libpcap as systems without development libraries installed may not have libpcap.so installed.

Fixes: #192

(Note: not tested yet.)