### PR TITLE
use SIGUSR2 instead of SIGTERM to break pcap_loop on Linux

### DIFF
--- a/src/protocolInterface/protocolInterface_pcap.cpp
+++ b/src/protocolInterface/protocolInterface_pcap.cpp
@@ -128,8 +128,11 @@ public:
 				auto* const pcap = _pcap.get();
 
 #ifdef __linux__
-				// Empty signal handler for when shutdown() wakes up this thread during termination
-				std::signal(SIGTERM, [](int){});
+				// Empty signal handler for when shutdown() wakes up this thread during termination.
+				// Use SIGUSR2 rather than SIGTERM: std::signal is process-wide, so installing a
+				// no-op SIGTERM handler would silently swallow the daemon's own SIGTERM and prevent
+				// graceful shutdown via systemd / kill -TERM.
+				std::signal(SIGUSR2, [](int){});
 #endif // __linux__
 
 				_pcapLibrary.loop(pcap, -1, &ProtocolInterfacePcapImpl::pcapLoopHandler, reinterpret_cast<u_char*>(this));
@@ -186,7 +189,7 @@ private:
 			}
 #ifdef __linux__
 			// On linux when using 3PCAP we also have to wake up the thread using a signal (see pcap_breakloop manpage, "multi-threaded application" section)
-			pthread_kill(_captureThread.native_handle(), SIGTERM);
+			pthread_kill(_captureThread.native_handle(), SIGUSR2);
 #endif // __linux__
 			_captureThread.join();
 		}


### PR DESCRIPTION
`ProtocolInterfacePcapImpl` installs a no-op SIGTERM handler in the PCAP capture thread so it can wake itself out of `pcap_loop` via `pthread_kill(thread, SIGTERM)` during shutdown (per `pcap_breakloop(3)` multi-threaded note).

But `std::signal` is process-wide, so this no-op handler also swallows SIGTERM directed at the embedding application. swift-corelibs-libdispatch on Linux uses `signalfd` to receive signals — `signalfd` only sees signals that were *blocked* on the receiving thread; if the kernel delivers SIGTERM to a thread where it's unblocked and a no-op handler is installed, the signal is consumed silently and the application's graceful-shutdown path never fires. Hosts using (Swift's) ServiceLifecycle saw intermittent shutdown hangs because of this.

Switch to SIGUSR2, which is reserved for application use, has no side-effects on the host process's SIGTERM disposition, and does the same job for waking `pcap_loop`.

Disclosure: Claude generated.