### PR TITLE
set unsolicited/command_type AEM fields in make_aem_aecpdu()

### DIFF
--- a/src/bindings/c/utils.cpp
+++ b/src/bindings/c/utils.cpp
@@ -153,6 +153,8 @@ avdecc_protocol_aem_aecpdu_t make_aem_aecpdu(protocol::AemAecpdu const& source) 
 		aecpdu.controller_entity_id = frame.getControllerEntityID();
 		aecpdu.sequence_id = frame.getSequenceID();
 		// AEM fields
+		aecpdu.unsolicited = frame.getUnsolicited() ? 1 : 0;
+		aecpdu.command_type = static_cast<avdecc_protocol_aem_command_type_t>(frame.getCommandType());
 		auto const [payload, payloadLength] = frame.getPayload();
 		aecpdu.command_specific_length = static_cast<decltype(aecpdu.command_specific_length)>(std::min(payloadLength, sizeof(aecpdu.command_specific)));
 		std::memcpy(aecpdu.command_specific, payload, aecpdu.command_specific_length);


### PR DESCRIPTION
The C bindings’` make_aem_aecpdu()` never populated the `unsolicited` or `command_type` fields when converting an AemAecpdu to its C representation, even though both are part of `avdecc_protocol_aem_aecpdu_s` and IEEE 1722.1 AECP AEM. Clients reading those fields off responses to identify the command class (e.g. `SET_SAMPLING_RATE`) saw zeros, making it impossible to associate a response with its originating command — observed downstream as AVDECC sample-rate-change responses arriving on the controller side with no way to tell what was being acknowledged, so the host application silently dropped them.

Forward both fields from `frame.getUnsolicited()` and `frame.getCommandType()` so language bindings (Swift, Python, etc.) can dispatch on response type.

Disclosure: AI generated.