### PR TITLE
Task/query input stream state fallback

### DIFF
--- a/CHANGELOG-controller.md
+++ b/CHANGELOG-controller.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- query InputStreamState if a pervious query for InputStreamInfoEx failed
+
 ## [4.3.1] - 2025-12-19
 ### Fixed
 - [Added option to ignore mismatching MVU responses Milan 1.0 devices responding with incorrect MVU command_type](https://github.com/L-Acoustics/avdecc/issues/195)

--- a/src/controller/avdeccControllerImplHandlers.cpp
+++ b/src/controller/avdeccControllerImplHandlers.cpp
@@ -3372,6 +3372,10 @@ void ControllerImpl::onGetStreamInputInfoExResult(entity::controller::Interface 
 					notifyObserversMethod<Controller::Observer>(&Controller::Observer::onEntityQueryError, this, controlledEntity.get(), QueryCommandError::GetStreamInputInfoEx);
 					return;
 				}
+				
+				// InputStreamInfoEx failed - query InputStreamState
+				queryInformation(controlledEntity.get(), configurationIndex,
+								 ControlledEntityImpl::DynamicInfoType::InputStreamState, streamIndex);
 			}
 
 			// Got all expected dynamic information


### PR DESCRIPTION
If a query for `ControlledEntityImpl::DynamicInfoType::InputStreamInfoEx` (Milan >= 1.3) fails the entity would end up without any input stream information.

Query `ControlledEntityImpl::DynamicInfoType::InputStreamState` in the case of a failure.